### PR TITLE
Documentation Typo

### DIFF
--- a/docs/tutorial/quick-start.md
+++ b/docs/tutorial/quick-start.md
@@ -74,7 +74,7 @@ You should now have the following structure:
 * `./auth_service/bus.py`, created above
 * `./another_service/`, which we will create files within now.
 
-We always we define a service's `bus` client within a `bus.py` file.
+We always define a service's `bus` client within a `bus.py` file.
 Therefore, create `./another_service/bus.py` containing the following:
 
 ```python3


### PR DESCRIPTION
I just want a small typo you'd probably want fixed :)

Also as a person working with code-analysis, I'd advice you to maybe use `"__main__"` when writing scripts etc, just to make sure you don't get sideeffects on imports :) 